### PR TITLE
Use cloud build for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,8 @@ concurrency:
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - "v?[0-9]+.[0-9]+.[0-9]+"
+      - "v?[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
 
 # To test workflow updates you need to work in a branch directly on viam-modules/uln2003
 # and tag your working branch instead of @main in any viam-modules/uln2003 "uses" below.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,40 +18,13 @@ jobs:
 
   publish:
     needs: test
-    strategy:
-      matrix:
-        include:
-          - arch: ubuntu-large
-            image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
-            platform: linux/amd64
-            label: amd64
-          - arch: github-linux-arm64-8core
-            image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
-            platform: linux/arm64
-            label: arm64
-
-    runs-on: ${{ matrix.arch }}
-    container:
-      image: ${{ matrix.image }}
-
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
+    - uses: viamrobotics/build-action@v1
       with:
-        go-version: 1.23
-
-    - name: Build module
-      run: |
-        sudo -u testbot bash -lc 'make module'
-
-    - name: Upload uln2003 module to registry
-      uses: viamrobotics/upload-module@main
-      with:
-        meta-path: meta.json
-        module-path: bin/module.tar.gz
-        platform: ${{ matrix.platform }}
         version: ${{ github.ref_name }}
+        ref: ${{ github.sha }}
         key-id: ${{ secrets.VIAM_DEV_API_KEY_ID }}
         key-value: ${{ secrets.VIAM_DEV_API_KEY }}
+        token: ${{ github.token }}


### PR DESCRIPTION
This PR updates the `uln2003` module to use `viamrobotics/build-action@v1` instead of constructing the builds manually