### PR TITLE
RSDK-12491: Fix threading issues and tight loop after completion

### DIFF
--- a/uln28byj48/28byj-48.go
+++ b/uln28byj48/28byj-48.go
@@ -462,8 +462,12 @@ func (m *uln28byj) SetPower(ctx context.Context, powerPct float64, extra map[str
 	}
 
 	m.lock.Lock()
-	direction := motor.GetSign(powerPct) // get the direction to set target to -ve/+ve Inf
-	m.targetStepPosition = int64(math.Inf(int(direction)))
+	// set the target to the min/max step position so the motor runs until stopped
+	if motor.GetSign(powerPct) < 0 {
+		m.targetStepPosition = math.MinInt64
+	} else {
+		m.targetStepPosition = math.MaxInt64
+	}
 	powerPct = motor.ClampPower(powerPct) // ensure 1.0 max and -1.0 min
 	m.stepperDelay = m.calcStepperDelay(powerPct * maxRPM)
 	m.lock.Unlock()

--- a/uln28byj48/28byj-48.go
+++ b/uln28byj48/28byj-48.go
@@ -40,6 +40,11 @@ var (
 	maxRPM               = 15.0                   // max rpm of the 28byj-48 motor after gear reduction
 )
 
+const (
+	stepModeHalf = "half"
+	stepModeFull = "full"
+)
+
 // halfStepSequence contains switching signal for uln2003 pins.
 // Treversing through halfStepSequence once is one step.
 var halfStepSequence = [8][4]bool{
@@ -99,7 +104,7 @@ func (conf *Config) Validate(path string) ([]string, []string, error) {
 		return nil, nil, resource.NewConfigValidationFieldRequiredError(path, "in4")
 	}
 
-	if conf.StepMode != "" && conf.StepMode != "half" && conf.StepMode != "full" {
+	if conf.StepMode != "" && conf.StepMode != stepModeHalf && conf.StepMode != stepModeFull {
 		return nil, nil, errors.New("step_mode must be 'half' or 'full'")
 	}
 
@@ -165,10 +170,10 @@ func new28byj(
 
 	// half step is the default for backward compatibility
 	switch mc.StepMode {
-	case "", "half":
+	case "", stepModeHalf:
 		m.stepSequence = make([][4]bool, len(halfStepSequence))
 		copy(m.stepSequence, halfStepSequence[:])
-	case "full":
+	case stepModeFull:
 		m.stepSequence = make([][4]bool, len(fullStepSequence))
 		copy(m.stepSequence, fullStepSequence[:])
 	default:
@@ -192,8 +197,6 @@ type uln28byj struct {
 	lock  sync.Mutex
 	opMgr *operation.SingleOperationManager
 
-	// workersMu guards workers. It must never be acquired while holding lock:
-	// stopping a worker waits for a goroutine that itself acquires lock.
 	workersMu sync.Mutex
 	workers   *utils.StoppableWorkers
 
@@ -205,7 +208,7 @@ type uln28byj struct {
 
 // doRun replaces any running worker with a new one that steps the motor
 // toward the target step position. The worker exits once the target is
-// reached (after de-energizing the pins) or the worker is stopped.
+// reached or the worker is stopped.
 func (m *uln28byj) doRun() {
 	m.workersMu.Lock()
 	defer m.workersMu.Unlock()

--- a/uln28byj48/28byj-48.go
+++ b/uln28byj48/28byj-48.go
@@ -189,11 +189,13 @@ type uln28byj struct {
 	motorName          string
 
 	// state
-	// TODO: state variables need to protected by a mutex in code
+	lock  sync.Mutex
+	opMgr *operation.SingleOperationManager
+
+	// workersMu guards workers. It must never be acquired while holding lock:
+	// stopping a worker waits for a goroutine that itself acquires lock.
+	workersMu sync.Mutex
 	workers   *utils.StoppableWorkers
-	lock      sync.Mutex
-	opMgr     *operation.SingleOperationManager
-	doRunDone func()
 
 	stepSequence       [][4]bool
 	stepPosition       int64
@@ -201,40 +203,41 @@ type uln28byj struct {
 	targetStepPosition int64
 }
 
-// doRun runs the motor till it reaches target step position.
+// doRun replaces any running worker with a new one that steps the motor
+// toward the target step position. The worker exits once the target is
+// reached (after de-energizing the pins) or the worker is stopped.
 func (m *uln28byj) doRun() {
-	// cancel doRun if it already exists
-	if m.doRunDone != nil {
-		m.doRunDone()
-	}
+	m.workersMu.Lock()
+	defer m.workersMu.Unlock()
 
-	// start a new doRun
-	// TODO: no need to have both a cancellable context and stoppable workers.
-	var doRunCtx context.Context
-	doRunCtx, m.doRunDone = context.WithCancel(context.Background())
+	if m.workers != nil {
+		m.workers.Stop()
+	}
 	m.workers = utils.NewBackgroundStoppableWorkers(func(ctx context.Context) {
-		for {
-			select {
-			case <-doRunCtx.Done():
+		for ctx.Err() == nil {
+			if m.getStepPosition() == m.getTargetStepPosition() {
+				if err := m.doStop(ctx); err != nil {
+					m.logger.Errorf("error setting pins to zero %v", err)
+				}
 				return
-			default:
 			}
 
-			// TODO: This is a tight infinite loop. Fix it.
-			if m.getStepPosition() == m.getTargetStepPosition() {
-				if err := m.doStop(doRunCtx); err != nil {
-					m.logger.Errorf("error setting pins to zero %v", err)
-					return
-				}
-			} else {
-				err := m.doStep(doRunCtx, m.getStepPosition() < m.getTargetStepPosition())
-				if err != nil {
-					m.logger.Errorf("error stepping %v", err)
-					return
-				}
+			if err := m.doStep(ctx, m.getStepPosition() < m.getTargetStepPosition()); err != nil {
+				m.logger.Errorf("error stepping %v", err)
+				return
 			}
 		}
 	})
+}
+
+// stopWorkers stops the background worker, if any, and waits for it to exit.
+func (m *uln28byj) stopWorkers() {
+	m.workersMu.Lock()
+	defer m.workersMu.Unlock()
+	if m.workers != nil {
+		m.workers.Stop()
+		m.workers = nil
+	}
 }
 
 // doStop sets all the pins to 0 to stop the motor.
@@ -364,7 +367,7 @@ func (m *uln28byj) GoFor(ctx context.Context, rpm, revolutions float64, extra ma
 
 	err = m.opMgr.WaitForSuccess(
 		ctx,
-		m.stepperDelay,
+		stepperDelay,
 		positionReached,
 	)
 	// Ignore the context canceled error - this occurs when the motor is stopped
@@ -456,11 +459,11 @@ func (m *uln28byj) SetPower(ctx context.Context, powerPct float64, extra map[str
 	}
 
 	m.lock.Lock()
-	defer m.lock.Unlock()
 	direction := motor.GetSign(powerPct) // get the direction to set target to -ve/+ve Inf
 	m.targetStepPosition = int64(math.Inf(int(direction)))
 	powerPct = motor.ClampPower(powerPct) // ensure 1.0 max and -1.0 min
 	m.stepperDelay = m.calcStepperDelay(powerPct * maxRPM)
+	m.lock.Unlock()
 
 	m.doRun()
 
@@ -491,14 +494,13 @@ func (m *uln28byj) IsMoving(ctx context.Context) (bool, error) {
 
 // Stop turns the power to the motor off immediately, without any gradual step down.
 func (m *uln28byj) Stop(ctx context.Context, extra map[string]interface{}) error {
-	if m.doRunDone != nil {
-		m.doRunDone()
-	}
-	m.lock.Lock()
-	defer m.lock.Unlock()
+	m.stopWorkers()
 
+	m.lock.Lock()
 	m.targetStepPosition = m.stepPosition
-	return nil
+	m.lock.Unlock()
+
+	return m.doStop(ctx)
 }
 
 // IsPowered returns whether or not the motor is currently on. It also returns the percent power
@@ -517,11 +519,5 @@ func (m *uln28byj) IsPowered(ctx context.Context, extra map[string]interface{}) 
 }
 
 func (m *uln28byj) Close(ctx context.Context) error {
-	if err := m.Stop(ctx, nil); err != nil {
-		return err
-	}
-	if m.workers != nil {
-		m.workers.Stop()
-	}
-	return nil
+	return m.Stop(ctx, nil)
 }

--- a/uln28byj48/28byj-48_test.go
+++ b/uln28byj48/28byj-48_test.go
@@ -337,6 +337,16 @@ func TestStateHalfStep(t *testing.T) {
 		err := m.ResetZeroPosition(ctx, -0.09, nil)
 		test.That(t, err, test.ShouldBeNil)
 		b := m.theBoard
+
+		// clear the pin writes made by the stop inside ResetZeroPosition so the
+		// assertions below only see the stepping sequence
+		for _, name := range []string{"1", "2", "3", "4"} {
+			pin, err := b.GPIOPinByName(name)
+			test.That(t, err, test.ShouldBeNil)
+			mockPin, ok := pin.(*mockGPIOPin)
+			test.That(t, ok, test.ShouldBeTrue)
+			mockPin.pinStates = nil
+		}
 		var pin1Arr []bool
 		var pin2Arr []bool
 		var pin3Arr []bool


### PR DESCRIPTION
Blast from the past...
The main fix here is fixing the infinite loop in `doRun` and removing redundant operation controls.
Tested manually.

Asked Claude to doublecheck the fix:

> I traced every public API path through the new code and through the pre-change (HEAD) code, and read the actual implementations of the three primitives the behavior hinges on: StoppableWorkers.Stop (cancels, then waits for the goroutine), SingleOperationManager.New (cancels the previous op and blocks until that op's method fully returns, and is nested-op aware so WaitForSuccess's inner New is a no-op), and RunInParallel (just passes ctx to each pin write — it doesn't pre-check cancellation itself).
> 
> Path-by-path: return point, pin state, pin-write count, what's left running
> 
> GoFor / GoTo (nonzero move), runs to completion. Returns once the poller sees position == target (poll period = stepperDelay), same as before. Pin writes: N steps x 4, plus exactly one final all-low write (4 calls) from the worker. Pre-change this was N x 4 plus an unbounded stream of all-low writes — the idle loop hammered doStop continuously until the next command. Afterward nothing is left running (worker de-energizes and exits). Pre-change a spinning goroutine remained forever. One benign race, present in both versions: GoFor can return a poll-tick before the worker's final all-low write lands, so pins may be energized for a few more microseconds after return.
> 
> GoFor with caller's context cancelled mid-move. Returns nil (the code deliberately swallows context.Canceled) while the worker keeps stepping to the target, then de-energizes and exits. Identical to pre-change except the goroutine now terminates instead of spinning at the target.
> 
> GoFor preempted by a new GoFor/SetPower. opMgr.New in the second call blocks until the first GoFor has fully returned, then the second call's doRun synchronously stops the old worker. Commands are fully serialized; at most one in-flight step completes on the old worker after preemption (pre-change: same one extra step, but with no wait and no guarantee).
> 
> GoTo with zero distance. Returns nil, zero pin writes, does not touch the worker — so a previously started SetPower run keeps going. Identical to pre-change.
> 
> SetPower / SetRPM (nonzero). Returns after handing off to a fresh worker. Worker runs indefinitely (target ±Inf) — intentional per the API. Exactly one goroutine exists regardless of how many commands were issued; pre-change each doRun leaked the previous StoppableWorkers object and briefly overlapped two stepping goroutines.
> 
> Stop / Close / ResetZeroPosition / zero-RPM GoFor / zero-power SetPower (all route through Stop). Behavioral deviations from pre-change, all intentional but worth your sign-off:
> 
> 1. Pins end all-low (4 writes). Pre-change Stop wrote nothing — pins stayed energized in the last step pattern (holding torque, coil heating) and a stopped worker could even issue one more step write after Stop returned. Now the end state is deterministic: worker fully exited, then pins low. Trade-off: holding torque is lost on Stop, and Close on a never-moved motor now writes pins where it previously wrote nothing.
> 2. Stop latency. Stop now waits for the in-flight step, and doStep sleeps holding the lock, so Stop can block up to one stepperDelay. At normal speeds that's ≤600ms, but at very low RPM the delay is 60/(rpm·ticks) seconds — a crawl-speed SetRPM makes Stop slow. Pre-change Stop returned instantly (at the cost of indeterminate aftermath).
> 3. New failure mode: Stop/Close called with an already-cancelled context can now return an error with pins not de-energized, because the all-low write uses the caller's ctx and real GPIO implementations honor cancellation. Pre-change Stop couldn't fail (it also didn't write anything). ResetZeroPosition inherits this error path. If you want Stop to be infallible, the de-energize write should use a background context — flagging, not changing.
> 
> ResetZeroPosition also gained correctness: pre-change it cancelled the worker without waiting, so an in-flight doStep could increment stepPosition after the reset, clobbering it. Now the worker is provably gone before the reset.